### PR TITLE
Dqm python3 fix

### DIFF
--- a/DQM/EcalCommon/python/CommonParams_cfi.py
+++ b/DQM/EcalCommon/python/CommonParams_cfi.py
@@ -4,8 +4,8 @@ ecalCommonParams = cms.untracked.PSet(
     onlineMode = cms.untracked.bool(False),
     willConvertToEDM = cms.untracked.bool(True)
 )
-ecaldqmLaserWavelengths = 1, 2, 3
-ecaldqmLedWavelengths = 1, 2
-ecaldqmMGPAGains = 12
-ecaldqmMGPAGainsPN = 16
 
+ecaldqmLaserWavelengths = cms.untracked.vint32(1, 2, 3)
+ecaldqmLedWavelengths = cms.untracked.vint32(1, 2)
+ecaldqmMGPAGains = cms.untracked.vint32(12)
+ecaldqmMGPAGainsPN = cms.untracked.vint32(16)

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -89,7 +89,7 @@ process.load("DQM.BeamMonitor.BeamMonitor_Pixel_cff")
 process.load("DQM.BeamMonitor.BeamSpotProblemMonitor_cff")
 process.load("DQM.BeamMonitor.BeamConditionsMonitor_cff")
 
-if process.dqmRunConfig.type.value() is "production":
+if process.dqmRunConfig.type.value() == "production":
   process.dqmBeamMonitor.BeamFitter.WriteAscii = True
   process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResultsOld.txt'
   process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -99,7 +99,7 @@ process.GlobalTag.DBParameters.authenticationPath = cms.untracked.string('.')
 
 # Change Beam Monitor variables
 process.dqmBeamMonitor.useLockRecords = cms.untracked.bool(useLockRecords)
-if process.dqmRunConfig.type.value() is "production":
+if process.dqmRunConfig.type.value() == "production":
   process.dqmBeamMonitor.BeamFitter.WriteAscii = True
   process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.txt'
   process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -213,7 +213,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 #----------------------------
 # File to save beamspot info
 #----------------------------
-if process.dqmRunConfig.type.value() is "production":
+if process.dqmRunConfig.type.value() == "production":
     process.pixelVertexDQM.fileName = "/nfshome0/dqmpro/BeamMonitorDQM/BeamPixelResults.txt"
 else:
     process.pixelVertexDQM.fileName = "/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt"

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -183,7 +183,7 @@ process.qie11Task_laser = process.qie11Task.clone(
    runkeyVal = runType,
    runkeyName = runTypeName,
    tagQIE11 = "hcalDigis",
-   subsystem = "HcalCalib",
+   subsystem = cms.untracked.string("HcalCalib"),
    laserType = 12
 )
 
@@ -192,7 +192,7 @@ process.qie11Task_pedestal = process.qie11Task.clone(
    runkeyVal = runType,
    runkeyName = runTypeName,
    tagQIE11 = "hcalDigis",
-   subsystem = "HcalCalib",
+   subsystem = cms.untracked.string("HcalCalib"),
    eventType = 1
 )
 

--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -33,7 +33,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 #-----------------------------
 
 # customise for playback
-if process.dqmRunConfig.type.value() is "playback":
+if process.dqmRunConfig.type.value() == "playback":
     process.dqmEnv.eventInfoFolder = 'EventInfo/Random'
 
 # DQM Modules

--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -112,7 +112,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 #----------------------
 process.load("DQM.PixelLumi.PixelLumiDQM_cfi") 
 
-if process.dqmRunConfig.type.value() is "playback":
+if process.dqmRunConfig.type.value() == "playback":
     process.pixel_lumi_dqm.logFileName = "pixel_lumi.txt"
 else:
     process.pixel_lumi_dqm.logFileName = "/nfshome0/dqmpro/pixel_lumi.txt"

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -243,7 +243,7 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
     process.SiStripAnalyserCosmic.TkMapCreationFrequency  = -1
     process.SiStripAnalyserCosmic.ShiftReportFrequency = -1
     process.SiStripAnalyserCosmic.StaticUpdateFrequency = 5
-    process.SiStripAnalyserCosmic.MonitorSiStripBackPlaneCorrection = False
+    process.SiStripAnalyserCosmic.MonitorSiStripBackPlaneCorrection = cms.bool(False)
     process.SiStripClients           = cms.Sequence(process.SiStripAnalyserCosmic)
     ### TRACKING
     process.load("DQM.TrackingMonitorClient.TrackingClientConfigP5_Cosmic_cff")
@@ -323,7 +323,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.SiStripAnalyser.ShiftReportFrequency = -1
     process.SiStripAnalyser.StaticUpdateFrequency = 5
     process.SiStripAnalyser.RawDataTag = "rawDataCollector"
-    process.SiStripAnalyser.MonitorSiStripBackPlaneCorrection = False
+    process.SiStripAnalyser.MonitorSiStripBackPlaneCorrection = cms.bool(False)
     process.SiStripClients           = cms.Sequence(process.SiStripAnalyser)
 
     process.SiStripMonitorDigi.TotalNumberOfDigisFailure.integrateNLumisections = 25
@@ -428,7 +428,7 @@ if (process.runType.getRunType() == process.runType.hpu_run):
     process.SiStripAnalyser.ShiftReportFrequency = -1
     process.SiStripAnalyser.StaticUpdateFrequency = 5
     process.SiStripAnalyser.RawDataTag = "rawDataCollector"
-    process.SiStripAnalyser.MonitorSiStripBackPlaneCorrection = False
+    process.SiStripAnalyser.MonitorSiStripBackPlaneCorrection = cms.bool(False)
     process.SiStripClients           = cms.Sequence(process.SiStripAnalyser)
     ### TRACKING
     process.load("DQM.TrackingMonitorClient.TrackingClientConfigP5_cff")
@@ -550,7 +550,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.SiStripAnalyser.ShiftReportFrequency = -1
     process.SiStripAnalyser.StaticUpdateFrequency = 5
     process.SiStripAnalyser.RawDataTag = "rawDataRepacker"
-    process.SiStripAnalyser.MonitorSiStripBackPlaneCorrection = False
+    process.SiStripAnalyser.MonitorSiStripBackPlaneCorrection = cms.bool(False)
     process.SiStripClients           = cms.Sequence(process.SiStripAnalyser)
 
     process.SiStripMonitorDigi.TotalNumberOfDigisFailure.integrateNLumisections = 25

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -63,7 +63,7 @@ if unitTest:
 process.source = source
 
 if not unitTest:
-    process.source.inputFileTransitionsEachEvent = True
+    process.source.inputFileTransitionsEachEvent = cms.untracked.bool(True)
     process.source.skipFirstLumis                = True
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -61,7 +61,7 @@ if unitTest:
 process.source = source
 
 if not unitTest:
-    process.source.inputFileTransitionsEachEvent = True
+    process.source.inputFileTransitionsEachEvent = cms.untracked.bool(True)
     process.source.skipFirstLumis                = True
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000

--- a/DQMServices/StreamerIO/scripts/esMonitoring.py
+++ b/DQMServices/StreamerIO/scripts/esMonitoring.py
@@ -219,13 +219,14 @@ class AsyncLineReaderMixin(object):
 
     def handle_read(self):
         rbuf = self.recv(1024*16)
+        rbuf = rbuf.decode('utf-8')
         ## not needed, since asyncore automatically handles close
         #if len(rbuf) == 0:
         #    self.handle_close()
         #    return
 
         self.line_buf.append(rbuf)
-        if b"\n" in rbuf:
+        if "\n" in rbuf:
             # split whatever we have
             spl = "".join(self.line_buf).split("\n")
 

--- a/DQMServices/StreamerIO/scripts/ztee.py
+++ b/DQMServices/StreamerIO/scripts/ztee.py
@@ -31,7 +31,7 @@ class GZipLog(object):
         self.file_truncate_state = None
 
     def write_block(self, data):
-        self.file.write(self.zstream.compress(data))
+        self.file.write(self.zstream.compress( data.encode("utf-8") ))
         self.file.write(self.zstream.flush(zlib.Z_FULL_FLUSH))
 
     def flush_block(self):


### PR DESCRIPTION
- Process parameter type is expected to be specified. For most of parameters it was possible to drop out types in assignment as they were specified previously somewhere. But for some parameters it is not possible e.g. ecaldqmLaserWavelengths, ecaldqmLedWavelengths or ecaldqmMGPAGains as they used to set parameters for the first time.
- socket, zlib compress works with bytes [0,1], not strings - decode/encode for simplicity

[0] https://docs.python.org/3/library/zlib.html
[1] https://docs.python.org/3/library/socket.html